### PR TITLE
fix: set default value for status

### DIFF
--- a/proj/pred/app/qd_fe.py
+++ b/proj/pred/app/qd_fe.py
@@ -894,6 +894,7 @@ def GetResult(jobid, query_para):#{{{
             pass
         isSuccess = False
         isFinish_remote = False
+        status = "N/A"  # set initial value for status
         if len(rtValue) >= 1:
             ss2 = rtValue[0]
             if len(ss2)>=3:


### PR DESCRIPTION
Set the default value for status so that the error of using of unassigned variable will be fixed. 